### PR TITLE
Remove deprecated import and up the optaplanner version

### DIFF
--- a/optaplanner-quickstart/pom.xml
+++ b/optaplanner-quickstart/pom.xml
@@ -10,7 +10,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-    <optaplanner-quarkus.version>9.37.0.Final</optaplanner-quarkus.version>
+    <optaplanner-quarkus.version>10.0.0</optaplanner-quarkus.version>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
@@ -43,10 +43,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest-jackson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-vertx-http-dev-console-spi</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
**Check list**:

Your pull request:

- [x] targets the `development` branch
- [x] uses the `999-SNAPSHOT` version of Quarkus
- [x] has tests (`mvn clean test`)
- [x] works in native (`mvn clean package -Pnative`)
- [x] has integration/native tests (`mvn clean verify -Pnative`)
- [x] makes sure the associated guide must not be updated
- [x] links the guide update pull request (if needed)
- [x] updates or creates the `README.md` file (with build and run instructions)
- [x] for new quickstart, is located in the directory _component-quickstart_
- [x] for new quickstart, is added to the root `pom.xml` and `README.md`


